### PR TITLE
Remove unncessary code for debugging the lobby user search query

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -321,12 +321,6 @@ const Chatroom = () => {
             return user.name.toLowerCase().includes(searchQuery.toLowerCase())
         })
     }, [lobbyUsers, searchQuery])
-
-    // Debugging search query
-    useEffect(() => {
-        console.log(searchQuery)
-    }, [searchQuery])
-
    
     return (
         <div className='bg-[url("./assets/bg.svg")] bg-cover h-full  text-white '>


### PR DESCRIPTION
Just a extra line of code I had in one of the previous PR (#7) that was used to check/debug the user query on the input field. Forgot to remove it after feature completion :stuck_out_tongue: 